### PR TITLE
Fix card export image scaling and include folded back.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1148,138 +1148,156 @@
 
         // Print Color Photo button handler
         printColorPhotoBtn.addEventListener('click', async () => {
+            // This button's primary function is to share with a printer app.
+            const dummyFile = new File(["dummy"], "dummy.png", { type: "image/png" });
+            if (!navigator.share || !navigator.canShare({ files: [dummyFile] })) {
+                showMessage(`Web Share not supported. Please use the "Download Card Image(s)" button and print manually from your photo app.`, true);
+                return;
+            }
+
             showMessage('Generating image(s) for color photo printer...');
             const cardsToProcess = appState.printScope === 'all' ? appState.cards : [appState.cards[appState.currentCardIndex]];
 
-            const originalCardIndex = appState.currentCardIndex; // Store original index
+            try {
+                const files = [];
+                for (const card of cardsToProcess) {
+                    const canvas = await generateCardCanvas(card, 'color', appState.thermalPaperSize); // Force 'color'
+                    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+                    files.push(new File([blob], `${card.title.replace(/\s/g, '_')}_card.png`, { type: 'image/png' }));
+                }
 
-            for (let i = 0; i < cardsToProcess.length; i++) {
-                const card = cardsToProcess[i];
-                appState.currentCardIndex = appState.cards.indexOf(card); // Set current card for rendering
-                updateCardPreview(); // Update preview to reflect the current card being processed
+                await navigator.share({
+                    files: files,
+                    title: `Print Card: ${cardsToProcess.length > 1 ? 'Multiple Cards' : cardsToProcess[0].title}`,
+                    text: 'Ready to print TTRPG card(s).',
+                });
+                showMessage('Image(s) sent to share dialog for printing.');
+            } catch (error) {
+                if (error.name === 'AbortError') {
+                    showMessage('Share cancelled.', false);
+                } else {
+                    console.error('Error preparing image for printing:', error);
+                    showMessage(`Error preparing image for printing: ${error.message}`, true);
+                }
+            }
+        });
 
-                const tempContainer = document.createElement('div');
-                tempContainer.style.position = 'absolute';
-                tempContainer.style.left = '-9999px';
-                tempContainer.style.width = '600px';
-                tempContainer.style.height = card.isFolded ? '1800px' : '900px';
+        // Refactored function to generate a canvas for a given card
+        async function generateCardCanvas(card, printerType, thermalPaperSize) {
+            const tempContainer = document.createElement('div');
+            tempContainer.style.position = 'absolute';
+            tempContainer.style.left = '-9999px';
+            // Use a specific class to scope the styles and queries
+            tempContainer.className = 'card-export-render-container';
+
+            let targetWidthPx;
+            let htmlContent = '';
+
+            // This logic is mostly extracted from the original download/share buttons
+            if (printerType === 'thermal') {
+                targetWidthPx = thermalPaperSize === '58mm' ? 384 : 576;
+                // For thermal, we let the content define the height. The container will have two divs.
+                tempContainer.style.width = `${targetWidthPx}px`;
+                htmlContent = await generateThermalHtmlForCard(card); // This function already produces a complete HTML string
+            } else { // 'color' printer type
+                targetWidthPx = 600;
+                // For folded color cards, the canvas is twice the height of the front (1:1.5 ratio)
+                const targetHeightPx = card.isFolded ? (targetWidthPx * 1.5 * 2) : (targetWidthPx * 1.5);
+                tempContainer.style.width = `${targetWidthPx}px`;
+                tempContainer.style.height = `${targetHeightPx}px`;
                 tempContainer.style.overflow = 'hidden';
-                tempContainer.style.backgroundColor = card.color || '#ffffff';
 
-                let iconRenderHtml = '';
+                // Simplified HTML generation for color cards
+                let iconHtml = '';
                 if (card.icon) {
-                    // New logic: Check manifest first, then URL, then Font Awesome
-                    if (iconManifest[card.icon]) {
-                        const iconPath = iconManifest[card.icon];
-                        iconRenderHtml = `<img src="${iconPath}" alt="${card.icon}" style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; object-fit: contain;" onerror="this.src='https://placehold.co/150x150/000/FFF?text=ICON';" />`;
-                    } else if (isURL(card.icon)) {
-                        iconRenderHtml = `<img src="${card.icon}" alt="Card Icon" style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; object-fit: contain;" onerror="this.src='https://placehold.co/150x150/000/FFF?text=IMG';" />`;
-                    } else {
-                        iconRenderHtml = `<i class="fa-solid fa-${card.icon}" style="position: absolute; top: 0.125in; right: 0.125in; font-size: 0.25in; width: 0.25in; height: 0.25in;"></i>`;
-                    }
+                    const iconUrl = iconManifest[card.icon] || (isURL(card.icon) ? card.icon : `https://placehold.co/48x48/E0E0E0/888?text=ICON`);
+                    iconHtml = `<img class="card-export-icon" src="${iconUrl}" style="position: absolute; top: 0.2in; right: 0.2in; width: 0.35in; height: 0.35in; object-fit: contain;" />`;
                 }
 
                 const frontHtml = `
-                    <div style="position: relative; width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: space-between; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000;">
-                    ${iconRenderHtml}
-                    <h1 style="font-size: 48px; margin-bottom: 10px; line-height: 1.2;">${card.title || ''}</h1>
-                    ${card.type ? `<p style="font-size: 28px; margin-bottom: 15px;">${card.type}</p>` : ''}
-
-                    <div style="flex-grow: 1; overflow: hidden; width: 100%;">
-                        ${(card.stats && Object.keys(card.stats).length > 0) ? `
-                        <div style="display: flex; flex-wrap: wrap; justify-content: center; margin-bottom: 15px; font-size: 24px;">
-                            ${Object.entries(card.stats).map(([key, value]) => `
-                            <span style="margin: 0 15px; white-space: nowrap;"><strong>${key || ''}:</strong> ${value || ''}</span>
-                            `).join('')}
+                    <div class="card-export-front" style="position: relative; width: ${targetWidthPx}px; height: ${targetWidthPx * 1.5}px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: space-between; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000;">
+                        ${iconHtml}
+                        <h1 style="font-size: 48px; margin-bottom: 10px; line-height: 1.2;">${card.title || ''}</h1>
+                        ${card.type ? `<p style="font-size: 28px; margin-bottom: 15px;">${card.type}</p>` : ''}
+                        <div style="flex-grow: 1; overflow: hidden; width: 100%;">
+                            ${(card.stats && Object.keys(card.stats).length > 0) ? `
+                            <div style="display: flex; flex-wrap: wrap; justify-content: center; margin-bottom: 15px; font-size: 24px;">
+                                ${Object.entries(card.stats).map(([key, value]) => `<span style="margin: 0 15px; white-space: nowrap;"><strong>${key || ''}:</strong> ${value || ''}</span>`).join('')}
+                            </div>` : ''}
+                            ${(card.sections && Array.isArray(card.sections)) ? card.sections.map(section => `
+                            <div style="margin-bottom: 15px; text-align: left;">
+                                ${section.heading ? `<h2 style="font-size: 32px; margin-bottom: 8px; border-bottom: 2px solid #ccc; padding-bottom: 4px;">${section.heading}</h2>` : ''}
+                                <p style="font-size: 24px; margin-bottom: 8px; line-height: 1.4;">${formatText(section.body || '')}</p>
+                                ${section.flavorText ? `<p style="font-size: 20px; font-style: italic; color: #555; margin-top: 8px;">${formatText(section.flavorText || '')}</p>` : ''}
+                            </div>`).join('') : ''}
                         </div>
-                        ` : ''}
+                        ${(card.tags && Array.isArray(card.tags) && card.tags.length > 0) ? `<p style="font-size: 20px; text-align: center; margin-top: 15px; border-top: 2px solid #ccc; padding-top: 8px;">Tags: ${card.tags.join(', ')}</p>` : ''}
+                        ${card.footer ? `<p style="font-size: 20px; text-align: center; margin-top: 15px;">${card.footer || ''}</p>` : ''}
+                    </div>`;
 
-                        ${(card.sections && Array.isArray(card.sections)) ? card.sections.map(section => `
-                        <div style="margin-bottom: 15px; text-align: left;">
-                            ${section.heading ? `<h2 style="font-size: 32px; margin-bottom: 8px; border-bottom: 2px solid #ccc; padding-bottom: 4px;">${section.heading}</h2>` : ''}
-                            <p style="font-size: 24px; margin-bottom: 8px; line-height: 1.4;">${formatText(section.body || '')}</p>
-                            ${section.flavorText ? `<p style="font-size: 20px; font-style: italic; color: #555; margin-top: 8px;">${formatText(section.flavorText || '')}</p>` : ''}
-                        </div>
-                        `).join('') : ''}
-                    </div>
-
-                    ${(card.tags && Array.isArray(card.tags) && card.tags.length > 0) ? `
-                        <p style="font-size: 20px; text-align: center; margin-top: 15px; border-top: 2px solid #ccc; padding-top: 8px;">Tags: ${card.tags.join(', ')}</p>
-                    ` : ''}
-                    ${card.footer ? `<p style="font-size: 20px; text-align: center; margin-top: 15px;">${card.footer || ''}</p>` : ''}
-                    </div>
-                `;
-                tempContainer.innerHTML = frontHtml;
+                htmlContent += frontHtml;
 
                 if (card.isFolded) {
+                    let backContentHtml = '';
+                    const foldContent = card.foldContent || {};
+                    if (foldContent.type === 'text' && foldContent.text) {
+                        backContentHtml = `<p style="font-size: 28px; margin: 0; line-height: 1.4;">${formatText(foldContent.text)}</p>`;
+                    } else if (foldContent.type === 'imageUrl' && foldContent.imageUrl) {
+                        const backImgUrl = iconManifest[foldContent.imageUrl] || foldContent.imageUrl;
+                        backContentHtml = `<img class="card-export-back-img" src="${backImgUrl}" style="max-width: 80%; max-height: 80%; object-fit: contain;" />`;
+                    } else if (foldContent.type === 'qrCode' && foldContent.qrCodeData) {
+                        const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(foldContent.qrCodeData)}`;
+                        backContentHtml = `<img class="card-export-qr" src="${qrUrl}" style="max-width: 300px; height: auto;" />`;
+                    }
+
                     const backHtml = `
-                        <div style="width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000; transform: rotate(180deg); transform-origin: center center;">
-                        ${(card.foldContent && card.foldContent.type === 'text' && card.foldContent.text) ? `
-                            <p style="font-size: 28px; margin: 0; line-height: 1.4;">${formatText(card.foldContent.text)}</p>
-                        ` : ''}
-                        ${(card.foldContent && card.foldContent.type === 'imageUrl' && card.foldContent.imageUrl) ? `
-                            <img src="${iconManifest[card.foldContent.imageUrl] || card.foldContent.imageUrl}" style="width: 100%; object-fit: contain;" onerror="this.src='https://placehold.co/300x300/000/FFF?text=BACK+IMG';" />
-                        ` : ''}
-                        ${(card.foldContent && card.foldContent.type === 'qrCode' && card.foldContent.qrCodeData) ? `
-                            <img src="https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(card.foldContent.qrCodeData)}" style="max-width: 300px; height: auto;" onerror="this.src='https://placehold.co/300x300/000/FFF?text=QR';" />
-                        ` : ''}
-                        </div>
-                    `;
-                    tempContainer.innerHTML += backHtml;
+                        <div class="card-export-back" style="width: ${targetWidthPx}px; height: ${targetWidthPx * 1.5}px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000; transform: rotate(180deg); transform-origin: center center;">
+                            ${backContentHtml}
+                        </div>`;
+                    htmlContent += backHtml;
                 }
-
-                document.body.appendChild(tempContainer);
-
-                if (printerType === 'thermal') {
-                    targetHeightPx = tempContainer.offsetHeight;
-                }
-
-                try {
-                    const canvas = await html2canvas(tempContainer, {
-                        scale: 1,
-                        useCORS: true,
-                        logging: false,
-                        width: 600,
-                        height: card.isFolded ? 1800 : 900,
-                    });
-
-                    const imageDataUrl = canvas.toDataURL('image/png');
-
-                    document.body.removeChild(tempContainer);
-
-                    if (navigator.share && navigator.canShare({ files: [] })) {
-                        try {
-                            const response = await fetch(imageDataUrl);
-                            const blob = await response.blob();
-                            const file = new File([blob], `${card.title.replace(/\s/g, '_')}_card.png`, { type: 'image/png' });
-
-                            await navigator.share({
-                                files: [file],
-                                title: `${card.title} TTRPG Card`,
-                                text: `Here's my custom TTRPG card: ${card.title}`,
-                            });
-                            showMessage(`Card "${card.title}" shared successfully!`);
-                        } catch (error) {
-                            console.error(`Error sharing file for "${card.title}":`, error);
-                            showMessage(`Failed to share card "${card.title}". Please ensure your device supports sharing images to printer apps.`, true);
-                        }
-                    } else {
-                        showMessage(`Web Share API not fully supported. Please download the image for "${card.title}" and share manually with your printer app (e.g., INSTAX Biz™ App, Kodak Step Prints App).`);
-                        downloadImage(imageDataUrl, card.title); // Pass title for unique filename
-                    }
-                } catch (error) {
-                    console.error(`Error generating image for "${card.title}":`, error);
-                    showMessage(`Failed to generate image for "${card.title}". Please try again.`, true);
-                    if (tempContainer.parentNode) {
-                        document.body.removeChild(tempContainer);
-                    }
-                }
-                await new Promise(resolve => setTimeout(resolve, 500)); // Small delay between processing cards
             }
-            appState.currentCardIndex = originalCardIndex; // Restore original index
-            updateCardPreview(); // Restore original preview
-            showMessage('Image generation/share process completed for selected cards.');
-        });
+
+            tempContainer.innerHTML = htmlContent;
+            document.body.appendChild(tempContainer);
+
+            // Pre-load all images inside the temporary container
+            const images = tempContainer.querySelectorAll('img');
+            const promises = [];
+            images.forEach(img => {
+                img.crossOrigin = 'Anonymous';
+                promises.push(new Promise((resolve) => {
+                    img.onload = resolve;
+                    img.onerror = () => {
+                        console.warn(`Could not load image: ${img.src}. It might not render correctly.`);
+                        const width = img.style.width || '100px';
+                        const height = img.style.height || '100px';
+                        img.src = `https://placehold.co/${parseInt(width)}x${parseInt(height)}/E0E0E0/888?text=LOAD_ERR`;
+                        resolve(); // Resolve even on error
+                    };
+                    // Force reload for cached images
+                    const currentSrc = img.src;
+                    img.src = '';
+                    img.src = currentSrc;
+                }));
+            });
+
+            await Promise.all(promises);
+
+            // Add a small delay to allow fonts to render if needed
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const canvas = await html2canvas(tempContainer, {
+                scale: 2, // Use a higher scale for better resolution
+                useCORS: true,
+                logging: false,
+                width: tempContainer.offsetWidth,
+                height: tempContainer.offsetHeight,
+            });
+
+            document.body.removeChild(tempContainer);
+            return canvas;
+        }
 
         // Download Image button handler
         function loadImage(src) {
@@ -1305,330 +1323,60 @@
         downloadImageBtn.addEventListener('click', async () => {
             showMessage('Generating image(s) for download...');
             const cardsToProcess = appState.printScope === 'all' ? appState.cards : [appState.cards[appState.currentCardIndex]];
+            const originalCardIndex = appState.currentCardIndex;
 
-            const originalCardIndex = appState.currentCardIndex; // Store original index
-
-            for (let i = 0; i < cardsToProcess.length; i++) {
-                const card = cardsToProcess[i];
-                appState.currentCardIndex = appState.cards.indexOf(card); // Set current card for rendering
-                updateCardPreview(); // Update preview to reflect the current card being processed
-
-                const printerType = appState.printerType;
-                const thermalPaperSize = appState.thermalPaperSize;
-
-                const tempContainer = document.createElement('div');
-                tempContainer.style.position = 'absolute';
-                tempContainer.style.left = '-9999px';
-
-                let targetWidthPx;
-                let targetHeightPx;
-
-                if (printerType === 'thermal') {
-                    targetWidthPx = thermalPaperSize === '58mm' ? 384 : 576;
-                    targetHeightPx = targetWidthPx * 1.4; // Maintain aspect ratio
-                    tempContainer.style.width = `${targetWidthPx}px`;
-                    tempContainer.style.height = `${targetHeightPx}px`;
-                    tempContainer.innerHTML = await generateThermalHtmlForCard(card);
-                } else {
-                    targetWidthPx = 600;
-                    targetHeightPx = card.isFolded ? (targetWidthPx * 1.4 * 2) : (targetWidthPx * 1.4);
-                    tempContainer.style.width = `${targetWidthPx}px`;
-                    tempContainer.style.height = `${targetHeightPx}px`;
-                    tempContainer.style.overflow = 'hidden';
-                    tempContainer.style.backgroundColor = card.color || '#ffffff';
-
-                    let iconRenderHtml = '';
-                    if (card.icon) {
-                        // New logic: Check manifest first, then URL, then Font Awesome
-                        if (iconManifest[card.icon]) {
-                            const iconPath = iconManifest[card.icon];
-                            iconRenderHtml = `<div style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; background-image: url('${iconPath}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>`;
-                        } else if (isURL(card.icon)) {
-                            iconRenderHtml = `<div style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; background-image: url('${card.icon}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>`;
-                        } else {
-                            iconRenderHtml = `<i class="fa-solid fa-${card.icon}" style="position: absolute; top: 0.125in; right: 0.125in; font-size: 0.25in; width: 0.25in; height: 0.25in; display: flex; justify-content: center; align-items: center;"></i>`;
-                        }
-                    }
-
-                    const frontHtml = `
-                        <div style="position: relative; width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: space-between; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000;">
-                        ${iconRenderHtml}
-                        <h1 style="font-size: 48px; margin-bottom: 10px; line-height: 1.2;">${card.title || ''}</h1>
-                        ${card.type ? `<p style="font-size: 28px; margin-bottom: 15px;">${card.type}</p>` : ''}
-
-                        <div style="flex-grow: 1; overflow: hidden; width: 100%;">
-                            ${(card.stats && Object.keys(card.stats).length > 0) ? `
-                            <div style="display: flex; flex-wrap: wrap; justify-content: center; margin-bottom: 15px; font-size: 24px;">
-                                ${Object.entries(card.stats).map(([key, value]) => `
-                                <span style="margin: 0 15px; white-space: nowrap;"><strong>${key || ''}:</strong> ${value || ''}</span>
-                                `).join('')}
-                            </div>
-                            ` : ''}
-
-                            ${(card.sections && Array.isArray(card.sections)) ? card.sections.map(section => `
-                            <div style="margin-bottom: 15px; text-align: left;">
-                                ${section.heading ? `<h2 style="font-size: 32px; margin-bottom: 8px; border-bottom: 2px solid #ccc; padding-bottom: 4px;">${section.heading}</h2>` : ''}
-                                <p style="font-size: 24px; margin-bottom: 8px; line-height: 1.4;">${formatText(section.body || '')}</p>
-                                ${section.flavorText ? `<p style="font-size: 20px; font-style: italic; color: #555; margin-top: 8px;">${formatText(section.flavorText || '')}</p>` : ''}
-                            </div>
-                            `).join('') : ''}
-                        </div>
-
-                        ${(card.tags && Array.isArray(card.tags) && card.tags.length > 0) ? `
-                            <p style="font-size: 20px; text-align: center; margin-top: 15px; border-top: 2px solid #ccc; padding-top: 8px;">Tags: ${card.tags.join(', ')}</p>
-                        ` : ''}
-                        ${card.footer ? `<p style="font-size: 20px; text-align: center; margin-top: 15px;">${card.footer || ''}</p>` : ''}
-                        </div>
-                    `;
-                    tempContainer.innerHTML = frontHtml;
-                        }
-
-                        if (card.isFolded) {
-                            const backHtml = `
-                            <div style="width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000; transform: rotate(180deg); transform-origin: center center;">
-                            ${(card.foldContent && card.foldContent.type === 'text' && card.foldContent.text) ? `
-                                <p style="font-size: 28px; margin: 0; line-height: 1.4;">${formatText(card.foldContent.text)}</p>
-                            ` : ''}
-                            ${(card.foldContent && card.foldContent.type === 'imageUrl' && card.foldContent.imageUrl) ? `
-                                <div style="width: 100%; height: 100%; background-image: url('${iconManifest[card.foldContent.imageUrl] || card.foldContent.imageUrl}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>
-                            ` : ''}
-                            ${(card.foldContent && card.foldContent.type === 'qrCode' && card.foldContent.qrCodeData) ? `
-                                <img src="https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(card.foldContent.qrCodeData)}" style="max-width: 300px; height: auto;" onerror="this.src='https://placehold.co/300x300/000/FFF?text=QR';" />
-                            ` : ''}
-                            </div>
-                        `;
-                            tempContainer.innerHTML += backHtml;
-                }
-
-                document.body.appendChild(tempContainer);
-
+            for (const card of cardsToProcess) {
+                // This loop doesn't need to update the main UI, just process cards.
                 try {
-                    const canvas = await html2canvas(tempContainer, {
-                        scale: 1,
-                        useCORS: true,
-                        logging: false,
-                        width: targetWidthPx,
-                        height: targetHeightPx
-                    });
-
-                    // Post-process the canvas to draw images correctly
-                    const ctx = canvas.getContext('2d');
-                    const iconUrl = iconManifest[card.icon] || (isURL(card.icon) ? card.icon : null);
-
-                    if (iconUrl) {
-                        const img = await loadImage(iconUrl);
-                        const iconSize = 0.25 * 96; // 0.25 inch at 96 DPI
-                        const margin = 0.125 * 96;
-                        const aspectRatio = img.width / img.height;
-                        let newWidth = iconSize;
-                        let newHeight = iconSize / aspectRatio;
-                        if (newHeight > iconSize) {
-                            newHeight = iconSize;
-                            newWidth = iconSize * aspectRatio;
-                        }
-                        ctx.drawImage(img, targetWidthPx - margin - newWidth, margin, newWidth, newHeight);
-                    }
-
-                    if (card.isFolded && card.foldContent.type === 'imageUrl' && card.foldContent.imageUrl) {
-                        const backImgUrl = iconManifest[card.foldContent.imageUrl] || card.foldContent.imageUrl;
-                        const backImg = await loadImage(backImgUrl);
-                        const backAspectRatio = backImg.width / backImg.height;
-                        let backWidth = targetWidthPx;
-                        let backHeight = targetWidthPx / backAspectRatio;
-                        if (backHeight > targetHeightPx / 2) {
-                            backHeight = targetHeightPx / 2;
-                            backWidth = backHeight * backAspectRatio;
-                        }
-                        const backY = targetHeightPx - backHeight;
-                        ctx.drawImage(backImg, (targetWidthPx - backWidth) / 2, backY, backWidth, backHeight);
-                    }
-
+                    const canvas = await generateCardCanvas(card, appState.printerType, appState.thermalPaperSize);
                     const imageDataUrl = canvas.toDataURL('image/png');
-                    downloadImage(imageDataUrl, card.title);
+                    downloadImage(imageDataUrl, card.title); // Use existing helper to download
                 } catch (error) {
                     console.error(`Error generating image for download for "${card.title}":`, error);
                     showMessage(`Failed to generate image for download for "${card.title}".`, true);
-                } finally {
-                    if (tempContainer.parentNode) {
-                        document.body.removeChild(tempContainer);
-                    }
                 }
-                await new Promise(resolve => setTimeout(resolve, 500)); // Small delay between processing cards
+                await new Promise(resolve => setTimeout(resolve, 100)); // Small delay between downloads
             }
-            appState.currentCardIndex = originalCardIndex; // Restore original index
-            updateCardPreview(); // Restore original preview
+
+            // Restore original state just in case, though we didn't change it.
+            appState.currentCardIndex = originalCardIndex;
+            updateCardPreview();
             showMessage('Image download process completed for selected cards.');
         });
 
         // Share Card button handler
         shareCardBtn.addEventListener('click', async () => {
             const dummyFile = new File(["dummy"], "dummy.png", { type: "image/png" });
-            if (navigator.share && navigator.canShare({ files: [dummyFile] })) {
-                showMessage('Preparing card(s) for sharing...');
-                try {
-                    const cardsToProcess = appState.printScope === 'all' ? appState.cards : [appState.cards[appState.currentCardIndex]];
-                    const files = [];
-
-                    for (const card of cardsToProcess) {
-                        const tempContainer = document.createElement('div');
-                        tempContainer.style.position = 'absolute';
-                        tempContainer.style.left = '-9999px';
-
-                        let targetWidthPx;
-                        let targetHeightPx;
-
-                        if (appState.printerType === 'thermal') {
-                            targetWidthPx = appState.thermalPaperSize === '58mm' ? 384 : 576;
-                            targetHeightPx = targetWidthPx * 1.4; // Maintain aspect ratio
-                            tempContainer.style.width = `${targetWidthPx}px`;
-                            tempContainer.style.height = `${targetHeightPx}px`;
-                            tempContainer.innerHTML = await generateThermalHtmlForCard(card);
-                        } else {
-                            targetWidthPx = 600;
-                            targetHeightPx = card.isFolded ? (targetWidthPx * 1.4 * 2) : (targetWidthPx * 1.4);
-                            tempContainer.style.width = `${targetWidthPx}px`;
-                            tempContainer.style.height = `${targetHeightPx}px`;
-                            tempContainer.style.overflow = 'hidden';
-                            tempContainer.style.backgroundColor = card.color || '#ffffff';
-
-                            let iconRenderHtml = '';
-                            if (card.icon) {
-                                // New logic: Check manifest first, then URL, then Font Awesome
-                                if (iconManifest[card.icon]) {
-                                    const iconPath = iconManifest[card.icon];
-                            iconRenderHtml = `<div style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; background-image: url('${iconPath}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>`;
-                                } else if (isURL(card.icon)) {
-                            iconRenderHtml = `<div style="position: absolute; top: 0.125in; right: 0.125in; width: 0.25in; height: 0.25in; background-image: url('${card.icon}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>`;
-                                } else {
-                                    iconRenderHtml = `<i class="fa-solid fa-${card.icon}" style="position: absolute; top: 0.125in; right: 0.125in; font-size: 0.25in; width: 0.25in; height: 0.25in; display: flex; justify-content: center; align-items: center;"></i>`;
-                                }
-                            }
-
-                            const frontHtml = `
-                            <div style="position: relative; width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: space-between; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000;">
-                            ${iconRenderHtml}
-                            <h1 style="font-size: 48px; margin-bottom: 10px; line-height: 1.2;">${card.title || ''}</h1>
-                            ${card.type ? `<p style="font-size: 28px; margin-bottom: 15px;">${card.type}</p>` : ''}
-
-                            <div style="flex-grow: 1; overflow: hidden; width: 100%;">
-                                ${(card.stats && Object.keys(card.stats).length > 0) ? `
-                                <div style="display: flex; flex-wrap: wrap; justify-content: center; margin-bottom: 15px; font-size: 24px;">
-                                    ${Object.entries(card.stats).map(([key, value]) => `
-                                    <span style="margin: 0 15px; white-space: nowrap;"><strong>${key || ''}:</strong> ${value || ''}</span>
-                                    `).join('')}
-                                </div>
-                                ` : ''}
-
-                                ${(card.sections && Array.isArray(card.sections)) ? card.sections.map(section => `
-                                <div style="margin-bottom: 15px; text-align: left;">
-                                    ${section.heading ? `<h2 style="font-size: 32px; margin-bottom: 8px; border-bottom: 2px solid #ccc; padding-bottom: 4px;">${section.heading}</h2>` : ''}
-                                    <p style="font-size: 24px; margin-bottom: 8px; line-height: 1.4;">${formatText(section.body || '')}</p>
-                                    ${section.flavorText ? `<p style="font-size: 20px; font-style: italic; color: #555; margin-top: 8px;">${formatText(section.flavorText || '')}</p>` : ''}
-                                </div>
-                                `).join('') : ''}
-                            </div>
-
-                            ${(card.tags && Array.isArray(card.tags) && card.tags.length > 0) ? `
-                                <p style="font-size: 20px; text-align: center; margin-top: 15px; border-top: 2px solid #ccc; padding-top: 8px;">Tags: ${card.tags.join(', ')}</p>
-                            ` : ''}
-                            ${card.footer ? `<p style="font-size: 20px; text-align: center; margin-top: 15px;">${card.footer || ''}</p>` : ''}
-                            </div>
-                        `;
-                            tempContainer.innerHTML = frontHtml;
-                        }
-
-                        if (card.isFolded) {
-                            if (appState.printerType !== 'thermal') {
-                                const backHtml = `
-                                <div style="width: 600px; height: 900px; font-family: 'Inter', sans-serif; padding: 20px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; background-color: ${card.color || '#ffffff'}; color: #000; transform: rotate(180deg); transform-origin: center center;">
-                                ${(card.foldContent && card.foldContent.type === 'text' && card.foldContent.text) ? `
-                                    <p style="font-size: 28px; margin: 0; line-height: 1.4;">${formatText(card.foldContent.text)}</p>
-                                ` : ''}
-                                ${(card.foldContent && card.foldContent.type === 'imageUrl' && card.foldContent.imageUrl) ? `
-                                    <div style="width: 100%; height: 100%; background-image: url('${iconManifest[card.foldContent.imageUrl] || card.foldContent.imageUrl}'); background-size: contain; background-repeat: no-repeat; background-position: center;"></div>
-                                ` : ''}
-                                ${(card.foldContent && card.foldContent.type === 'qrCode' && card.foldContent.qrCodeData) ? `
-                                    <img src="https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(card.foldContent.qrCodeData)}" style="max-width: 300px; height: auto;" onerror="this.src='https://placehold.co/300x300/000/FFF?text=QR';" />
-                                ` : ''}
-                                </div>
-                            `;
-                                tempContainer.innerHTML += backHtml;
-                            }
-                        }
-
-                        document.body.appendChild(tempContainer);
-
-                        if (appState.printerType === 'thermal') {
-                            targetHeightPx = tempContainer.offsetHeight;
-                        }
-
-                        try {
-                            const canvas = await html2canvas(tempContainer, {
-                                scale: 1,
-                                useCORS: true,
-                                logging: false,
-                                width: targetWidthPx,
-                                height: targetHeightPx,
-                            });
-
-                            // Post-process the canvas to draw images correctly
-                            const ctx = canvas.getContext('2d');
-                            const iconUrl = iconManifest[card.icon] || (isURL(card.icon) ? card.icon : null);
-
-                            if (iconUrl) {
-                                const img = await loadImage(iconUrl);
-                                const iconSize = 0.25 * 96; // 0.25 inch at 96 DPI
-                                const margin = 0.125 * 96;
-                                const aspectRatio = img.width / img.height;
-                                let newWidth = iconSize;
-                                let newHeight = iconSize / aspectRatio;
-                                if (newHeight > iconSize) {
-                                    newHeight = iconSize;
-                                    newWidth = iconSize * aspectRatio;
-                                }
-                                ctx.drawImage(img, targetWidthPx - margin - newWidth, margin, newWidth, newHeight);
-                            }
-
-                            if (card.isFolded && card.foldContent.type === 'imageUrl' && card.foldContent.imageUrl) {
-                                const backImgUrl = iconManifest[card.foldContent.imageUrl] || card.foldContent.imageUrl;
-                                const backImg = await loadImage(backImgUrl);
-                                const backAspectRatio = backImg.width / backImg.height;
-                                let backWidth = targetWidthPx;
-                                let backHeight = targetWidthPx / backAspectRatio;
-                                if (backHeight > targetHeightPx / 2) {
-                                    backHeight = targetHeightPx / 2;
-                                    backWidth = backHeight * backAspectRatio;
-                                }
-                                const backY = targetHeightPx - backHeight;
-                                ctx.drawImage(backImg, (targetWidthPx - backWidth) / 2, backY, backWidth, backHeight);
-                            }
-
-                            const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
-                            files.push(new File([blob], `${card.title.replace(/\s/g, '_')}_card.png`, { type: 'image/png' }));
-                        } finally {
-                            document.body.removeChild(tempContainer);
-                        }
-                    }
-
-                    showMessage('Ready to share. Opening share dialog...');
-                    await navigator.share({
-                        files: files,
-                        title: 'TTRPG Cards',
-                        text: 'Here are the TTRPG cards I made.',
-                    });
-                    showMessage('Card(s) shared successfully!');
-
-                } catch (error) {
-                    console.error('Error sharing files:', error);
-                    // Check for AbortError, which occurs when the user cancels the share sheet
-                    if (error.name === 'AbortError') {
-                        showMessage('Share cancelled.', false);
-                    } else {
-                        showMessage(`Error sharing: ${error.message}`, true);
-                    }
-                }
-            } else {
+            if (!navigator.share || !navigator.canShare({ files: [dummyFile] })) {
                 showMessage('Web Share API for files not supported on this device/browser. Please download the image and share manually.', true);
+                return;
+            }
+
+            showMessage('Preparing card(s) for sharing...');
+            try {
+                const cardsToProcess = appState.printScope === 'all' ? appState.cards : [appState.cards[appState.currentCardIndex]];
+                const files = [];
+
+                for (const card of cardsToProcess) {
+                    const canvas = await generateCardCanvas(card, appState.printerType, appState.thermalPaperSize);
+                    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+                    files.push(new File([blob], `${card.title.replace(/\s/g, '_')}_card.png`, { type: 'image/png' }));
+                }
+
+                showMessage('Ready to share. Opening share dialog...');
+                await navigator.share({
+                    files: files,
+                    title: 'TTRPG Cards',
+                    text: 'Here are the TTRPG cards I made.',
+                });
+                showMessage('Card(s) shared successfully!');
+            } catch (error) {
+                if (error.name === 'AbortError') {
+                    showMessage('Share cancelled.', false);
+                } else {
+                    console.error('Error sharing files:', error);
+                    showMessage(`Error sharing: ${error.message}`, true);
+                }
             }
         });
 


### PR DESCRIPTION
The previous implementation for downloading or sharing cards had two main issues:
1. Exported images were improperly scaled, showing only a portion of the intended image.
2. The back of folded cards was not included in the final export.

This was caused by a fragile rendering method that attempted to draw images onto the canvas after the initial render, and incorrect container height calculations for folded cards.

This change refactors the export logic into a single robust function, `generateCardCanvas`, which is now used by the download, share, and print buttons.

The new implementation fixes the issues by:
- Pre-loading all images before rendering the canvas to prevent timing issues.
- Increasing the `html2canvas` render scale to fix the resolution and scaling problem.
- Ensuring the container for folded cards is correctly sized to include both the front and the rotated back.
- Simplifying the overall logic and removing duplicated code across multiple button handlers.