### PR TITLE
feat: Unhide and fix android thermal print button

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,6 +731,7 @@
             togglePrinterTypeOptions();
             updateCardNavigationUI(); // Update card navigation UI
             updateCardPreview();
+            updatePrintLink();
         }
 
         // Save state to localStorage
@@ -1356,7 +1357,7 @@
                         numCopies: appState.numCopies
                     }
                 };
-                const encodedData = btoa(JSON.stringify(dataToSend));
+                const encodedData = btoa(encodeURIComponent(JSON.stringify(dataToSend)));
 
                 const cardViewUrl = new URL('index.html', window.location.href);
                 cardViewUrl.searchParams.set('view', 'card');

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@
                 cardViewUrl.searchParams.set('view', 'card');
                 cardViewUrl.searchParams.set('data', encodedData);
 
-                const printUrl = `print://escpos.org/escpos/bt/print?srcTp=uri&srcObj=html&numCopies=${appState.numCopies}&src='${cardViewUrl.toString()}'`;
+                const printUrl = `print://escpos.org/escpos/bt/print?srcTp=uri&srcObj=html&numCopies=${appState.numCopies}&src='${encodeURIComponent(cardViewUrl.toString())}'`;
                 printButton.href = printUrl;
                 printButton.classList.remove('hidden');
             } else {


### PR DESCRIPTION
This commit addresses two issues with the 'Print to Thermal Printer' button on Android:

1.  The button was not correctly configured on page load. The `updatePrintLink()` function, which sets the special `print://` URL and manages visibility, was not called. This has been fixed by calling it from `updateUIFromAppState()`.

2.  The data being passed to the printer service via the URL was not being properly encoded. It was missing `encodeURIComponent`, which could cause issues with special characters. This has been corrected in the `updatePrintLink()` function.