### PR TITLE
fix: Prevent JSON parse error in PDF generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1791,11 +1791,12 @@
                 let isFirstPage = true;
                 let allFrontPages = [];
                 // FIX: Use the 'cards' parameter directly.
-                for (const card of cards) {
-                    if (!card) continue; // Safety check for undefined cards
-                    const frontPages = await splitCardIntoPages(card);
-                    allFrontPages.push(...frontPages);
-                }
+                const pageArrays = await Promise.all(
+                    cards
+                        .filter(card => card)
+                        .map(card => splitCardIntoPages(card))
+                );
+                allFrontPages.push(...pageArrays.flat());
 
                 for (const page of allFrontPages) {
                     const canvases = await generateCardCanvas(page, false);

--- a/index.html
+++ b/index.html
@@ -1750,9 +1750,9 @@
             if (appState.isScrolling) {
                 // --- Scrolling Card Logic ---
                 let fullHtml = '<div>';
-                const cardsToProcess = appState.printScope === 'all' ? cards : [cards[appState.currentCardIndex]];
-
-                for (const card of cardsToProcess) {
+                // FIX: Use the 'cards' parameter directly. The caller now determines which cards to process.
+                for (const card of cards) {
+                    if (!card) continue; // Safety check
                     fullHtml += await generateScrollingHtmlForCard(card);
                 }
                 fullHtml += '</div>';
@@ -1790,9 +1790,9 @@
                 // --- Multi-Page Logic ---
                 let isFirstPage = true;
                 let allFrontPages = [];
-                const cardsToProcess = appState.printScope === 'all' ? cards : [cards[appState.currentCardIndex]];
-
-                for (const card of cardsToProcess) {
+                // FIX: Use the 'cards' parameter directly.
+                for (const card of cards) {
+                    if (!card) continue; // Safety check for undefined cards
                     const frontPages = await splitCardIntoPages(card);
                     allFrontPages.push(...frontPages);
                 }
@@ -1825,7 +1825,9 @@
                 }
 
                 // After all front pages are rendered, add the back pages for any folded cards
-                const foldedCardsWithBacks = cardsToProcess.filter(card => {
+                // FIX: Use the 'cards' parameter directly.
+                const foldedCardsWithBacks = cards.filter(card => {
+                    if (!card) return false; // Safety check
                     const shouldPrintBack = (foldOverride !== null) ? foldOverride : card.isFolded;
                     const hasBackContent = card.foldContent && (card.foldContent.text || card.foldContent.imageUrl || card.foldContent.qrCodeData);
                     return shouldPrintBack && hasBackContent;


### PR DESCRIPTION
The `generatePdfDocument` function was incorrectly redefining the list of cards to be processed, which could lead to an 'undefined' value being passed to `JSON.parse` when sharing a PDF of the current card.

This change removes the faulty logic and ensures the function correctly uses the `cards` parameter that is passed to it. Safety checks have also been added to prevent errors if an undefined card is encountered.